### PR TITLE
ci(docs): invoke `mkdocs` via `uv run`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,8 +43,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: "pyproject.toml"
-          # Issue ref: https://github.com/actions/setup-python/issues/436
-          cache: "pip"
       - name: Build docs
         run: |
           uv run --only-group=docs --only-group=workspaces --all-extras -- mkdocs build 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,12 +45,9 @@ jobs:
           python-version-file: "pyproject.toml"
           # Issue ref: https://github.com/actions/setup-python/issues/436
           cache: "pip"
-      - name: Sync docs environment
-        run: |
-          uv sync --only-group=docs --only-group=workspaces --all-extras
       - name: Build docs
         run: |
-          mkdocs build
+          uv run --only-group=docs --only-group=workspaces --all-extras -- mkdocs build 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
When the virtual environment is not activated, we need to use `uv run` to execute commands within the virtual environment.