### PR TITLE
feat(internal/pytauri): support specifying `entry_point` by package name

### DIFF
--- a/crates/pytauri/CHANGELOG.md
+++ b/crates/pytauri/CHANGELOG.md
@@ -24,7 +24,8 @@
 
 ### Internal
 
-- [#52](https://github.com/WSH032/pytauri/pull/52) - internal: set `sys._pytauri_standalone=True` when built as standalone app (i.e., launch from rust).
+- [#54](https://github.com/WSH032/pytauri/pull/54) - feat: export the extension module to `sys.modules["__pytauri_ext_mod__"]` if on standalone mode.
+- [#52](https://github.com/WSH032/pytauri/pull/52) - feat: set `sys._pytauri_standalone=True` when run on standalone app (i.e., launch from rust).
 - [#51](https://github.com/WSH032/pytauri/pull/51) - refactor: use `Python::run` with `locals` as arguments to execute `_append_ext_mod.py` for better performance.
 
 ## [0.1.0-beta.0]

--- a/crates/pytauri/src/_post_init_pyi.py
+++ b/crates/pytauri/src/_post_init_pyi.py
@@ -1,5 +1,4 @@
 import sys
-from importlib.metadata import entry_points
 from multiprocessing import set_executable, set_start_method
 from types import ModuleType
 from typing import TYPE_CHECKING, cast
@@ -44,20 +43,10 @@ set_executable(CURRENT_EXE)
 # see the implementation of `multiprocessing.spawn.get_command_line`
 setattr(sys, "frozen", True)  # noqa: B010
 
-# a private custom var, to info python we are built as standalone app.
+# a private custom var, to info python we are running as standalone app.
 setattr(sys, "_pytauri_standalone", True)  # noqa: B010
 
 
 ### Append Ext Mod  ###
 
-if sys.version_info >= (3, 10):
-    # To avoid deprecation warnings
-    eps = entry_points(group="pytauri", name="ext_mod")
-else:
-    # TODO: how to specify the name?
-    eps = entry_points()["pytauri"]
-
-
-ext_mod_path = next(iter(eps)).value
-
-sys.modules[ext_mod_path] = EXT_MOD
+sys.modules["__pytauri_ext_mod__"] = EXT_MOD

--- a/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
+++ b/examples/tauri-app/src-tauri/python/tauri_app/__init__.py
@@ -2,6 +2,14 @@
 
 """The tauri-app."""
 
+from os import environ
+
+# This is an env var that can only be used internally by pytauri to distinguish
+# between different example extension modules.
+# You don't need and shouldn't set this in your own app.
+# Must be set before importing any pytauri module.
+environ["_PYTAURI_DIST"] = "tauri-app"
+
 import sys
 from datetime import datetime
 

--- a/python/pytauri/CHANGELOG.md
+++ b/python/pytauri/CHANGELOG.md
@@ -9,6 +9,12 @@
 - [#48](https://github.com/WSH032/pytauri/pull/48) - feat: accessing the `WebviewWindow` in `Commands`.
 - [#49](https://github.com/WSH032/pytauri/pull/49) - feat: add `Event`, `EventId`, `Listener`, `ImplListener` for [Event System](https://tauri.app/develop/calling-frontend/#event-system).
 
+### Internal
+
+- [#54](https://github.com/WSH032/pytauri/pull/54)
+    - feat: import the extension module from `sys.modules["__pytauri_ext_mod__"]` if on standalone mode (`sys._pytauri_standalone`).
+    - feat: support specifying `entry_point` package name which be used to import the extension module via `os.environ["_PYTAURI_DIST"]` (only for non-standalone mode).
+
 ## [0.1.0-beta.0]
 
 [unreleased]: https://github.com/WSH032/pytauri/tree/HEAD

--- a/python/pytauri/src/pytauri/ffi/_ext_mod.py
+++ b/python/pytauri/src/pytauri/ffi/_ext_mod.py
@@ -1,3 +1,5 @@
+import sys
+from os import getenv
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -6,14 +8,30 @@ from typing import TYPE_CHECKING
 # Deprecated: once we no longer support versions Python 3.9, we can remove this dependency.
 from importlib_metadata import (
     EntryPoint,
+    distribution,
     entry_points,  # pyright: ignore[reportUnknownVariableType]
 )
 
 __all__ = ["EXT_MOD", "pytauri_mod"]
 
+_SPECIFIC_DIST = getenv("_PYTAURI_DIST")
+"""specify the package distribution name of a pytauri app to load the extension module."""
+
 
 def _load_ext_mod() -> ModuleType:
-    eps: tuple[EntryPoint, ...] = tuple(entry_points(group="pytauri", name="ext_mod"))
+    # See: `crates/pytauri/src/_post_init_pyi.py`.
+    if getattr(sys, "_pytauri_standalone", False):
+        return sys.modules["__pytauri_ext_mod__"]
+
+    group = "pytauri"
+    name = "ext_mod"
+    eps = (
+        entry_points(group=group, name=name)
+        if not _SPECIFIC_DIST
+        else distribution(_SPECIFIC_DIST).entry_points.select(group=group, name=name)  # pyright: ignore[reportUnknownMemberType]
+    )
+    eps: tuple[EntryPoint, ...] = tuple(eps)
+
     if len(eps) == 0:
         raise RuntimeError("No `pytauri` entry point is found")
     elif len(eps) > 1:


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

- export/import the extension module from `sys.modules["__pytauri_ext_mod__"]` if on standalone mode (`sys._pytauri_standalone`).
- support specifying `entry_point` package name which be used to import the extension module via `os.environ["_PYTAURI_DIST"]` (only for non-standalone mode).

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
