### PR TITLE
perf(pytauri)!: all IPC methods only accept `bytes` as parameters now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### BREAKING
 
+- [#56](https://github.com/WSH032/pytauri/pull/56) - perf(pytauri): all IPC methods that previously accepted `bytearray` as a parameter now only accept `bytes` as a parameter.
 - [#52](https://github.com/WSH032/pytauri/pull/52) - refactor(standalone)!: new API for preparing python interpreter.
     The `pytauri::standalone` module has been completely rewritten.
     Previously, you used `prepare_freethreaded_python_with_executable` and `append_ext_mod`. Now, you need to use `PythonInterpreterBuilder`.

--- a/crates/pytauri-core/CHANGELOG.md
+++ b/crates/pytauri-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### BREAKING
+
+- [#56](https://github.com/WSH032/pytauri/pull/56) - perf: `Invoke::bind_to` now returns `[Self::BODY_KEY]`: `PyBytes` instead of `PyByteArray`.
+
 ### Added
 
 - [#50](https://github.com/WSH032/pytauri/pull/50) - feat: add `ipc::Channel`, `ipc::JavaScriptChannelId`, `webview::Webview`, `webview::WebviewWindow::as_ref::<webview>` for [channels ipc](https://tauri.app/develop/calling-frontend/#channels).

--- a/crates/pytauri-core/src/ext_mod_impl/ipc.rs
+++ b/crates/pytauri-core/src/ext_mod_impl/ipc.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, str::FromStr as _};
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
-    types::{PyByteArray, PyDict, PyMapping, PyString, PyType},
+    types::{PyBytes, PyDict, PyMapping, PyString, PyType},
 };
 use pyo3_utils::py_wrapper::{PyWrapper, PyWrapperT0, PyWrapperT2};
 use tauri::ipc::{
@@ -122,7 +122,7 @@ impl Invoke {
     /// Pass in a Python dictionary, which can contain the following
     /// optional keys (values are arbitrary):
     ///
-    /// - [Self::BODY_KEY] : [PyByteArray]
+    /// - [Self::BODY_KEY] : [PyBytes]
     /// - [Self::APP_HANDLE_KEY] : [crate::ext_mod::AppHandle]
     /// - [Self::WEBVIEW_WINDOW_KEY] : [crate::ext_mod::webview::WebviewWindow]
     ///
@@ -159,7 +159,7 @@ impl Invoke {
                     return Ok(None);
                 }
                 InvokeBody::Raw(body) => {
-                    arguments.set_item(Self::BODY_KEY, PyByteArray::new(py, body))?
+                    arguments.set_item(Self::BODY_KEY, PyBytes::new(py, body))?
                 }
             }
         }

--- a/python/pytauri/CHANGELOG.md
+++ b/python/pytauri/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### BREAKING
+
+- [#56](https://github.com/WSH032/pytauri/pull/56) - perf: all IPC methods that previously accepted `bytearray` as a parameter now only accept `bytes` as a parameter.
+
 ### Added
 
 - [#50](https://github.com/WSH032/pytauri/pull/50) - feat: add `ipc::Channel`, `ipc::JavaScriptChannelId`, `webview::Webview`, `webview::WebviewWindow::as_ref::<webview>` for [channels ipc](https://tauri.app/develop/calling-frontend/#channels).

--- a/python/pytauri/src/pytauri/ffi/ipc.py
+++ b/python/pytauri/src/pytauri/ffi/ipc.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     Generic,
     Optional,
-    Union,
     final,
 )
 
@@ -52,7 +51,7 @@ class ArgumentsType(TypedDict, total=False):
     You can use it like `**kwargs`, for example `command(**arguments)`.
     """
 
-    body: bytearray
+    body: bytes
     """The body of ipc message."""
     app_handle: "AppHandle"
     """The handle of the app."""
@@ -86,7 +85,7 @@ if TYPE_CHECKING:
             is not the same object as the input `parameters`.
             """
 
-        def resolve(self, value: Union[bytearray, bytes]) -> None:
+        def resolve(self, value: bytes) -> None:
             """Consumes this `Invoke` and resolves the command with the given value."""
             ...
 
@@ -103,7 +102,7 @@ if TYPE_CHECKING:
             """The bound arguments of the current command."""
             ...
 
-        def resolve(self, value: Union[bytearray, bytes]) -> None:
+        def resolve(self, value: bytes) -> None:
             """Consumes this `InvokeResolver` and resolves the command with the given value."""
 
         def reject(self, value: str) -> None:
@@ -136,7 +135,7 @@ if TYPE_CHECKING:
             """The channel identifier."""
             ...
 
-        def send(self, data: Union[bytearray, bytes], /) -> None:
+        def send(self, data: bytes, /) -> None:
             """Sends the given data through the channel."""
             ...
 


### PR DESCRIPTION


<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

No longer accept `bytearray` as parameters.
It's for reducing maintenance burden and improving performance.

# Checklist

- [X] I've read `CONTRIBUTING.md`.
- [X] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [X] I've updated the documentation and/or `CHANGELOG.md` accordingly.
