### PR TITLE
feat(pytauri)!: add `BuilderArgs::setup` to support setup hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
+- [#80](https://github.com/WSH032/pytauri/pull/80) - `example/nicegui-app`:
+    - Use `BuilderArgs.setup` for initialization instead of listening to the `RunEvent.Ready` event.
+    - Rewrite the `FrontServer` `startup`/`shutdown` event hook logic.
+    - Modularize the code.
 - [#79](https://github.com/WSH032/pytauri/pull/79) - `example/nicegui-app`:
     - use `tray` and `menu` feature
     - use `python3.10` `match` statement instead of `if-else` statement

--- a/crates/pytauri-core/CHANGELOG.md
+++ b/crates/pytauri-core/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### BREAKING
 
+- [#80](https://github.com/WSH032/pytauri/pull/80) - refactor: `trait PyAppHandleExt` is now sealed and no longer has generic parameters.
 - [#79](https://github.com/WSH032/pytauri/pull/79) - pref: the fields of `enum RunEvent` `struct` variants become `Py<T>` types from rust types.
 
 ### Added
 
+- [#80](https://github.com/WSH032/pytauri/pull/80) - feat: add `PyAppHandleExt::get_or_init_py_app_handle`, and the methods return `&Py<AppHandle>` instead of `impl Deref<Target = Py<AppHandle>>` now.
 - [#79](https://github.com/WSH032/pytauri/pull/79) - feat: implement [tauri `tray` feature](https://tauri.app/learn/system-tray/):
     enable `tauri/tray-icon` feature
     - `mod tauri::`

--- a/crates/pytauri-core/src/ext_mod_impl/ipc.rs
+++ b/crates/pytauri-core/src/ext_mod_impl/ipc.rs
@@ -171,7 +171,7 @@ impl Invoke {
         let app_handle_key = intern!(py, Invoke::APP_HANDLE_KEY);
         if parameters.contains(app_handle_key)? {
             let py_app_handle = message.webview_ref().try_py_app_handle()?;
-            arguments.set_item(app_handle_key, &*py_app_handle)?;
+            arguments.set_item(app_handle_key, py_app_handle)?;
         }
 
         let webview_window_key = intern!(py, Invoke::WEBVIEW_WINDOW_KEY);

--- a/crates/pytauri/CHANGELOG.md
+++ b/crates/pytauri/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- [#80](https://github.com/WSH032/pytauri/pull/80) - feat: `BuilderArgs`:
+    - add `BuilderArgs::setup` to support tauri app setup hook.
+    - `BuilderArgs::context` now can be `Position and Keyword` arguments.
+
 ## [0.2.0]
 
 ### BREAKING

--- a/examples/nicegui-app/python/nicegui_app/__init__.py
+++ b/examples/nicegui-app/python/nicegui_app/__init__.py
@@ -7,10 +7,7 @@ from os import environ
 environ["_PYTAURI_DIST"] = "nicegui-app"
 
 import sys
-from concurrent.futures import Future
-from socket import socket
-from threading import Event
-from typing import Any, Optional
+from typing import Callable
 
 import uvicorn
 from anyio.from_thread import start_blocking_portal
@@ -27,45 +24,9 @@ from pytauri import (
 )
 from pytauri.webview import WebviewWindow
 from pytauri_plugin_notification import NotificationExt
-from typing_extensions import override
 
+from nicegui_app._server import FrontServer
 from nicegui_app._tray_menu import init_menu, init_tray
-
-
-class FrontServer(uvicorn.Server):
-    """Override `uvicorn.Server` to set events on startup and shutdown."""
-
-    def __init__(
-        self, config: uvicorn.Config, *, startup_event: Event, shutdown_event: Event
-    ) -> None:
-        super().__init__(config)
-        self.startup_event = startup_event
-        self.shutdown_event = shutdown_event
-
-    @override
-    async def startup(self, sockets: Optional[list[socket]] = None) -> None:
-        """Set the startup event after the server is started."""
-        await super().startup(sockets)
-        self.startup_event.set()
-
-    @override
-    async def shutdown(self, sockets: Optional[list[socket]] = None) -> None:
-        """Set the shutdown event after the server is shutdown."""
-        await super().shutdown(sockets)
-        self.shutdown_event.set()
-
-    def request_shutdown(self) -> None:
-        """Request the server to shutdown.
-
-        Note:
-            This method is not thread-safe.
-
-        Ref:
-            - <https://github.com/zauberzeug/nicegui/discussions/1957#discussioncomment-7484548>
-            - <https://github.com/encode/uvicorn/discussions/1103#discussioncomment-6187606>
-        """
-        self.should_exit = True
-
 
 app_handle: AppHandle
 """We will initialize it in the `main` function later."""
@@ -74,7 +35,7 @@ webview_window: WebviewWindow
 
 
 @ui.page("/")
-def root_ui() -> None:
+def root() -> None:
     """Draw the nicegui UI and set event callbacks."""
 
     # Since we only display the window after `app_handle` and `webview_window` are initialized,
@@ -96,83 +57,67 @@ def root_ui() -> None:
     message = ui.label()
 
 
+def app_setup_hook(front_server: FrontServer) -> Callable[[AppHandle], None]:
+    """Set the global var `app_handle` and `webview_window`;
+    and initialize the ui, tray icon and menu;
+    and show the main window once the front server is ready.
+    """
+
+    def _app_setup_hook(app_handle_: AppHandle) -> None:
+        global app_handle
+        app_handle = app_handle_
+
+        webview_window_ = Manager.get_webview_window(app_handle, "main")
+        assert (
+            webview_window_ is not None
+        ), "you forgot to set the unvisible 'main' window in `tauri.conf.json`"
+        global webview_window
+        webview_window = webview_window_
+
+        # wait for the front server to start and show the window
+        front_server.wait_for_startup()
+
+        # initialize the tray icon and menu
+        init_tray(app_handle, webview_window)
+        init_menu(app_handle)
+        webview_window.show()
+        if front_server.serve_exception is not None:
+            webview_window.eval(
+                "document.body.innerHTML = `failed to start front server, see backend logs for details`"
+            )
+
+    return _app_setup_hook
+
+
 def main() -> None:
     nicegui_app = FastAPI()
     ui.run_with(nicegui_app)
-    server_startup_event = Event()
-    server_shutdown_event = Event()
-    server = FrontServer(
+    front_server = FrontServer(
         # `host` and `port` are the same as `frontendDist` in `tauri.conf.json`
         uvicorn.Config(nicegui_app, host="localhost", port=8080),
-        shutdown_event=server_shutdown_event,
-        startup_event=server_startup_event,
     )
 
     with start_blocking_portal("asyncio") as portal:  # or `trio`
-        server_exception: Optional[BaseException] = None
-
-        def server_failed_callback(future: Future[Any]) -> None:
-            """Add a callback to check if the server broke down."""
-            nonlocal server_exception
-            server_exception = future.exception()
-            if server_exception is not None:
-                # server startup failed, so we must set these events manually for app,
-                # or the app will hang for waiting these `Event`s forever.
-                server_startup_event.set()
-                server_shutdown_event.set()
-
         # launch the front server
-        portal.start_task_soon(server.serve).add_done_callback(server_failed_callback)
+        portal.start_task_soon(front_server.serve)
 
         # launch the app
         tauri_app = builder_factory().build(
             BuilderArgs(
-                context=context_factory(),
+                context_factory(),
+                setup=app_setup_hook(front_server),
             )
         )
 
-        # set the global variable `app_handle`.
-        global app_handle
-        app_handle = tauri_app.handle()
-
-        def tauri_run_callback(app_handle: AppHandle, run_event: RunEventType) -> None:
+        def tauri_run_callback(_: AppHandle, run_event: RunEventType) -> None:
             """Add a callback to show the main window after the server is started and
             shutdown the server when the app is going to exit."""
 
             match run_event:
-                # show the main window after the server is started,
-                # and set the global variable `webview_window`.
-                case RunEvent.Ready():
-                    webview_window_ = Manager.get_webview_window(app_handle, "main")
-                    assert (
-                        webview_window_ is not None
-                    ), "you forgot to set the unvisible 'main' window in `tauri.conf.json`"
-                    global webview_window
-                    webview_window = webview_window_
-
-                    # initialize the tray icon and menu
-                    init_tray(app_handle, webview_window_)
-                    init_menu(app_handle)
-
-                    # wait for the front server to start and show the window
-                    server_startup_event.wait()
-                    webview_window_.show()
-
-                    # check is the server failed to start, if so, show the error message.
-                    if (
-                        server_exception is not None
-                        or server.should_exit  # server/nicegui_app startup failed
-                    ):
-                        webview_window_.eval(
-                            "document.body.innerHTML = `failed to start front server, see backend logs for details`"
-                        )
-
                 # user closed the window so the app is going to exit,
                 # we need shutdown the front server first.
                 case RunEvent.Exit():
-                    server.request_shutdown()
-                    server_shutdown_event.wait()
-
+                    front_server.request_shutdown()
                 case _:
                     pass
 

--- a/examples/nicegui-app/python/nicegui_app/_server.py
+++ b/examples/nicegui-app/python/nicegui_app/_server.py
@@ -1,0 +1,56 @@
+from socket import socket
+from threading import Event
+from typing import Optional
+
+import uvicorn
+from typing_extensions import override
+
+__all__ = ["FrontServer"]
+
+
+class FrontServer(uvicorn.Server):
+    """Subclass `uvicorn.Server` to allow listening for startup and shutdown events."""
+
+    def __init__(self, config: uvicorn.Config) -> None:
+        super().__init__(config)
+        # NOTE: use `threading.Event` instead of `anyio.Event` for cross-thread communication
+        self._startup_event = Event()
+        self._shutdown_event = Event()
+        self._serve_exception: Optional[Exception] = None
+
+    @property
+    def serve_exception(self) -> Optional[Exception]:
+        """The exception raised during serving the application."""
+        return self._serve_exception
+
+    @override
+    async def startup(self, sockets: Optional[list[socket]] = None) -> None:
+        """Set the startup event after the server is started."""
+        await super().startup(sockets)
+        self._startup_event.set()
+
+    @override
+    async def serve(self, sockets: list[socket] | None = None) -> None:
+        """The main entry point to serve the application."""
+        try:
+            await super().serve(sockets)
+        except Exception as exc:
+            self._serve_exception = exc
+            raise
+        finally:
+            # set all the events whatever in case of exception
+            self._startup_event.set()
+            self._shutdown_event.set()
+
+    def wait_for_startup(self) -> None:
+        """Block until the server is started."""
+        self._startup_event.wait()
+
+    def request_shutdown(self) -> None:
+        """Request and block to wait for the server to shutdown."""
+        # Ref:
+        # - <https://github.com/zauberzeug/nicegui/discussions/1957#discussioncomment-7484548>
+        # - <https://github.com/encode/uvicorn/discussions/1103#discussioncomment-6187606>
+        self.should_exit = True
+
+        self._shutdown_event.wait()

--- a/examples/nicegui-app/python/nicegui_app/_tray_menu.py
+++ b/examples/nicegui-app/python/nicegui_app/_tray_menu.py
@@ -5,6 +5,8 @@ from pytauri.menu import Menu, MenuEvent, MenuItem, PredefinedMenuItem
 from pytauri.tray import MouseButton, TrayIcon, TrayIconEvent, TrayIconEventType
 from pytauri.webview import WebviewWindow
 
+__all__ = ["init_menu", "init_tray"]
+
 
 def init_tray(app_handle: AppHandle, webview_window: WebviewWindow) -> None:
     """Initialize the tray icon."""
@@ -25,6 +27,7 @@ def init_tray(app_handle: AppHandle, webview_window: WebviewWindow) -> None:
     )
 
     def on_menu_event(app_handle: AppHandle, menu_event: MenuEvent) -> None:
+        """Hide, show or quit the app when the tray menu is clicked."""
         match menu_event:
             case "Hide":
                 webview_window.hide()
@@ -52,7 +55,7 @@ def init_tray(app_handle: AppHandle, webview_window: WebviewWindow) -> None:
 
 
 def init_menu(app_handle: AppHandle) -> None:
-    """Initialize the app menu."""
+    """Initialize the default app menu."""
 
     menu = Menu.default(app_handle)
     menu.set_as_app_menu()

--- a/python/pytauri/CHANGELOG.md
+++ b/python/pytauri/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- [#80](https://github.com/WSH032/pytauri/pull/80) - feat: `BuilderArgs`:
+    - add `BuilderArgs::setup` to support tauri app setup hook.
+    - `BuilderArgs::context` now can be `Position and Keyword` arguments.
 - [#79](https://github.com/WSH032/pytauri/pull/79) - feat: implement [tauri `tray` feature](https://tauri.app/learn/system-tray/):
     enable `tauri/tray-icon` feature
     - `mod tauri::`

--- a/python/pytauri/src/pytauri/ffi/lib.py
+++ b/python/pytauri/src/pytauri/ffi/lib.py
@@ -165,9 +165,10 @@ if TYPE_CHECKING:
         def __new__(
             cls,
             /,
-            *,
             context: "Context",
+            *,
             invoke_handler: Optional[_InvokeHandlerProto] = None,
+            setup: Optional[Callable[[AppHandle], object]] = None,
         ) -> Self:
             """[tauri::Builder](https://docs.rs/tauri/latest/tauri/struct.Builder.html)
 
@@ -179,6 +180,7 @@ if TYPE_CHECKING:
             Args:
                 context: use [context_factory][pytauri.context_factory] to get it.
                 invoke_handler: use [Commands][pytauri.ipc.Commands] to get it.
+                setup: see rust `tauri::Builder::setup`.
             """
             ...
 


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

Added:

- add `BuilderArgs::setup`
- `BuilderArgs::context` now can be `Position and Keyword` arguments
- add `PyAppHandleExt::get_or_init_py_app_handle`, and the methods return `&Py<AppHandle>` instead of `impl Deref<Target = Py<AppHandle>>` now.

Docs:

- `example/nicegui-app`:
    - Use `BuilderArgs.setup` for initialization instead of listening to the `RunEvent.Ready` event.
    - Rewrite the `FrontServer` `startup`/`shutdown` event hook logic.
    - Modularize the code.

BREAKING CHANGE:

- `trait PyAppHandleExt` is now sealed and no longer has generic parameters.

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
