### PR TITLE
perf(pytauri): use `Cow<'_, [u8]>` instead of `Vec<u8>` as pyfunc params

### DIFF
--- a/crates/pytauri-core/CHANGELOG.md
+++ b/crates/pytauri-core/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Changed
 
+- [#86](https://github.com/WSH032/pytauri/pull/86) - pref: use `Cow<'_, [u8]>` instead of `Vec<u8>` as `pymehtods`/`pyfunction` and `extract` parameters to improve performance.
+    see [PyO3/pyo3#3310](https://github.com/PyO3/pyo3/issues/3310#issuecomment-2674022839) and [PyO3/pyo3#2888](https://github.com/PyO3/pyo3/issues/2888) for more details.
 - [#79](https://github.com/WSH032/pytauri/pull/79) - perf: almost all of pyo3 `pymethods` will release the `GIL` now.
 - [#76](https://github.com/WSH032/pytauri/pull/76) - perf: use `pyo3::intern!` in `Invoke::bind_to` for commands `IPC` performance.
 - [#75](https://github.com/WSH032/pytauri/pull/75) - perf: all methods of `WebviewWindow` will release the `GIL` now.


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁

1. Give the PR a descriptive title.

    See: <https://www.conventionalcommits.org/en/v1.0.0/>

    Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

    Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. Ensure that all your commits are signed.
    See: <https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>
4. Propose your changes as a draft PR if your work is still in progress.
-->

# Summary

- pref: use `Cow<'_, [u8]>` instead of `Vec<u8>` as `pymehtods`/`pyfunction` and `extract` parameters to improve performance.

    See [PyO3/pyo3#3310](https://github.com/PyO3/pyo3/issues/3310#issuecomment-2674022839) and [PyO3/pyo3#2888](https://github.com/PyO3/pyo3/issues/2888) for more details.

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion/issue. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation and/or `CHANGELOG.md` accordingly.
